### PR TITLE
@md-oss/cftools.js

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
           embed-author-url: "https://mirasaki.dev"
           embed-author-icon-url: "https://mirasaki.dev/logo.png"
           embed-color: 14228765
-          embed-title: "⬇️ @mirasaki/cftools.js"
+          embed-title: "⬇️ @md-oss/cftools.js"
           embed-description: "⌛ Deploying **`@${{ github.repository }}`**...\n📤 Service is now temporarily unavailable."
 
   deploy:
@@ -77,5 +77,5 @@ jobs:
           embed-author-url: "https://mirasaki.dev"
           embed-author-icon-url: "https://mirasaki.dev/logo.png"
           embed-color: 9559538
-          embed-title: "⬆️ @mirasaki/cftools.js"
+          embed-title: "⬆️ @md-oss/cftools.js"
           embed-description: "✅ Finished deploying **`@${{ github.repository }}`**\n📥 [Service](https://cftools.mirasaki.dev) is back online"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Installation
 
 ```bash
-npm install @mirasaki/cftools.js --save
+npm install @md-oss/cftools.js --save
 ```
 
 ## Usage
@@ -15,8 +15,8 @@ npm install @mirasaki/cftools.js --save
 The main entrypoint for this package/library is the `CFToolsClient`. It provides convenience methods to interact with the API, and provides 100% coverage of the Data API.
 
 ```js
-import { CFToolsClient } from '@mirasaki/cftools.js'; // ESM
-const { CFToolsClient } = require('@mirasaki/cftools.js'); // CommonJS
+import { CFToolsClient } from '@md-oss/cftools.js'; // ESM
+const { CFToolsClient } = require('@md-oss/cftools.js'); // CommonJS
 
 // Instantiate our client, the `serverApiId` can be
 // omitted and overwritten in individual requests

--- a/documents/Usage.md
+++ b/documents/Usage.md
@@ -3,8 +3,8 @@
 The `CFToolsClient` is the main entrypoint for this library. It provides convenience methods around the CFTools Data API which can be found [here](https://developer.cftools.cloud/documentation/data-api). This document serves as an introduction to the CFTools Data API and the implementation inside this package.
 
 ```js
-import { CFToolsClient } from '@mirasaki/cftools.js'; // ESM
-const { CFToolsClient } = require('@mirasaki/cftools.js'); // CommonJS
+import { CFToolsClient } from '@md-oss/cftools.js'; // ESM
+const { CFToolsClient } = require('@md-oss/cftools.js'); // CommonJS
 
 // Instantiate our client, the `serverApiId` can be
 // omitted and overwritten in individual requests
@@ -22,7 +22,7 @@ For a complete overview of what the client can do, please check out the [API ref
 The following example wraps around updating a priority queue entry. This serves as an complete example on how this library and it's client are used, including error handling.
 
 ```js
-import { isNotFoundError, isMissingServerApiIdError, isDuplicateEntryError } from '@mirasaki/cftools.js';
+import { isNotFoundError, isMissingServerApiIdError, isDuplicateEntryError } from '@md-oss/cftools.js';
 
 // Do something with the client
 const handlePriorityQueue = (
@@ -83,7 +83,7 @@ handlePriorityQueue('76500000000000000')
 To enable the usage of the Enterprise API - the CFTools Data API without any strict rate limits (except for the global Cloudflare limit of 6000 requests per minute) - you can simply provide the token that is privately obtained from the CFTools team in the Client constructor:
 
 ```js
-import { CFToolsClient } from '@mirasaki/cftools.js';
+import { CFToolsClient } from '@md-oss/cftools.js';
 
 const client = new CFToolsClient({
   applicationId: process.env.CFTOOLS_APPLICATION_ID,
@@ -115,7 +115,7 @@ Please note, both the Enterprise API and explicitly provided permission from the
 The following example demonstrates how to modify the caching set-up for your client.
 
 ```js
-import { CFToolsClient } from '@mirasaki/cftools.js';
+import { CFToolsClient } from '@md-oss/cftools.js';
 
 const client = new CFToolsClient({
   applicationId: process.env.CFTOOLS_APPLICATION_ID,
@@ -149,7 +149,7 @@ const client = new CFToolsClient({
 The following example demonstrates how to change the logging level for your client.
 
 ```js
-import { CFToolsClient, ConsoleLogger } from '@mirasaki/cftools.js';
+import { CFToolsClient, ConsoleLogger } from '@md-oss/cftools.js';
 
 const logger = new ConsoleLogger(logLevel);
 const client = new CFToolsClient({
@@ -160,7 +160,7 @@ const client = new CFToolsClient({
 The following example demonstrates how to attach a custom logger to your instantiated client, allowing for details logs to be saved locally or otherwise. This example uses the `ConsoleLogger` implementation, but it's very easy so switch out for [`winston`](https://www.npmjs.com/package/winston) - as an example.
 
 ```js
-import { CFToolsClient, AbstractLogger } from '@mirasaki/cftools.js';
+import { CFToolsClient, AbstractLogger } from '@md-oss/cftools.js';
 
 class ConsoleLogger extends AbstractLogger implements AbstractLogger {
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@mirasaki/cftools.js",
+  "name": "@md-oss/cftools.js",
   "version": "1.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@mirasaki/cftools.js",
+      "name": "@md-oss/cftools.js",
       "version": "1.0.12",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mirasaki/cftools.js",
+  "name": "@md-oss/cftools.js",
   "version": "1.0.12",
   "description": "JavaScript implementation for the CFTools Data API.",
   "publishConfig": {
@@ -53,7 +53,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Mirasaki-Development/cftools.js.git"
+    "url": "git+https://github.com/Mirasaki/cftools.js.git"
   },
   "keywords": [
     "cftools",
@@ -70,7 +70,7 @@
   },
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/Mirasaki-Development/cftools.js/issues"
+    "url": "https://github.com/Mirasaki/cftools.js/issues"
   },
   "dependencies": {
     "cache-manager": "^6.1.2",


### PR DESCRIPTION
The package is now maintained at `@md-oss`, to prevent authorization issues with our private `@mirasaki` GitHub registry.